### PR TITLE
#29 Feature/delete task

### DIFF
--- a/components/Form.js
+++ b/components/Form.js
@@ -37,9 +37,8 @@ const renderComponents = ({ index, type, value, options, props, autoFocus, error
       onChangeText={onChange}
     />;
   case 'switch':
-    return <View style={styles.switchContainer}>
+    return <View key={index} style={styles.switchContainer}>
       <Switch
-        key={index}
         {...props}
         trackColor={{ false: '#767577', true: '#81b0ff' }}
         thumbColor={value ? '#f5dd4b' : '#f4f3f4'}

--- a/components/Form.js
+++ b/components/Form.js
@@ -6,6 +6,9 @@ import { Dropdown } from 'react-native-material-dropdown';
 const inputs = [];
 
 const renderComponents = ({ index, type, value, options, props, autoFocus, errorMsg, onSubmit, onChange }) => {
+  if (props.hidden) {
+    return;
+  }
   switch (type) {
   case 'text':
     return <Input

--- a/components/Form.js
+++ b/components/Form.js
@@ -1,8 +1,55 @@
 import React, { useState } from 'react';
-import { Input } from 'react-native-elements';
+import { View, Switch, StyleSheet } from 'react-native';
+import { Input, Text } from 'react-native-elements';
 import { Dropdown } from 'react-native-material-dropdown';
 
 const inputs = [];
+
+const renderComponents = ({ index, type, value, options, props, autoFocus, errorMsg, onSubmit, onChange }) => {
+  switch (type) {
+  case 'text':
+    return <Input
+      key={index}
+      {...props}
+      defaultValue={value}
+      autoFocus={autoFocus && index === 0 ? true : false}
+      ref={(input) => inputs[index] = input}
+      returnKeyType={inputs[index+1] ? 'next' : 'send'}
+      onSubmitEditing={()=> inputs[index+1] ? inputs[index+1].focus() : onSubmit()}
+      onChangeText={onChange}
+      errorStyle={{ color: 'red' }}
+      errorMessage={errorMsg}
+    />;
+  case 'dropdown':
+    return <Dropdown
+      key={index}
+      containerStyle={{ padding: 10, paddingTop: 0 }}
+      labelFontSize={16}
+      baseColor="rgba(0,0,0,0.5)"
+      label={props.label}
+      rippleOpacity={0}
+      animationDuration={200}
+      data={options}
+      value={value}
+      onChangeText={onChange}
+    />;
+  case 'switch':
+    return <View style={styles.switchContainer}>
+      <Switch
+        key={index}
+        {...props}
+        trackColor={{ false: '#767577', true: '#81b0ff' }}
+        thumbColor={value ? '#f5dd4b' : '#f4f3f4'}
+        ios_backgroundColor='#3e3e3e'
+        onValueChange={() => onChange(!value)}
+        value={value}
+      />
+      <Text style={{ fontSize: 16, padding: 3 }}>{value ? props.enabledLabel : props.disabledLabel} </Text>
+    </View>;
+  default:
+    return;
+  }
+};
 
 export default function Form({ fields = [], errors = [], defaultValue = {}, autoFocus = true, onUpdate, onSubmit }) {
   const [data, setData] = useState(defaultValue);
@@ -11,40 +58,33 @@ export default function Form({ fields = [], errors = [], defaultValue = {}, auto
     <React.Fragment>
       {
         fields.map(({ key, type = 'text', options, props = {} }, index) => {
-          const onChangeText = (value)=>{
+          const onChange = (value)=>{
             data[key] = value;
             setData({ ...data });
             onUpdate && onUpdate(data);
           };
-          return (
-            type === 'text' ?
-              <Input
-                key={index}
-                {...props}
-                defaultValue={data[key]}
-                autoFocus={autoFocus && index === 0 ? true : false}
-                ref={(input) => inputs[index] = input}
-                returnKeyType={inputs[index+1] ? 'next' : 'send'}
-                onSubmitEditing={()=> inputs[index+1] ? inputs[index+1].focus() : onSubmit()}
-                onChangeText={onChangeText}
-                errorStyle={{ color: 'red' }}
-                errorMessage={errors[index]}
-              /> :
-              <Dropdown
-                key={index}
-                containerStyle={{ padding: 10, paddingTop: 0 }}
-                labelFontSize={16}
-                baseColor="rgba(0,0,0,0.5)"
-                label={props.label}
-                rippleOpacity={0}
-                animationDuration={200}
-                data={options}
-                value={data[key]}
-                onChangeText={onChangeText}
-              />
-          );
+          return renderComponents({
+            index,
+            type,
+            value: data[key],
+            options,
+            props,
+            autoFocus,
+            errorMsg: errors[index],
+            onSubmit,
+            onChange,
+          });
         })
       }
     </React.Fragment>
   );
 }
+
+const styles = StyleSheet.create({
+  switchContainer: {
+    flex: 1,
+    alignItems: 'flex-start',
+    flexDirection: 'row',
+    marginBottom: 16,
+  },
+});

--- a/components/ModifyTask.js
+++ b/components/ModifyTask.js
@@ -17,6 +17,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
   const [errors, setErrors] = useState([]);
 
   const isModified = inTask ? true : false;
+  const isActive = task.isActive;
 
   const handleSubmit = async () => {
     if (isModified && !await check('ORG_TX__UPDATE', true)) return;
@@ -56,6 +57,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
     } else {
       const data = {
         organizationId,
+        isActive: task.isActive ? 1 : 0,
         name: task.name,
         programName: task.programName,
         description: task.description,
@@ -81,6 +83,14 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
 
   const fields = [
     {
+      key: 'isActive',
+      props: {
+        enabledLabel: '使用中',
+        disabledLabel: '停用中',
+      },
+      type: 'switch',
+    },
+    {
       key: 'programName',
       required: true,
       props: {
@@ -88,6 +98,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
         autoCorrect: false,
         autoCapitalize: 'none',
         placeholder: 'ex: 學校表現 日常工作',
+        disabled: !isActive,
       },
     },
     {
@@ -96,6 +107,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '任務名稱',
         autoCorrect: false,
+        disabled: isModified || !isActive,
       },
     },
     {
@@ -104,6 +116,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '任務內容',
         autoCorrect: false,
+        disabled: !isActive,
       },
     },
     {
@@ -112,6 +125,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '點數',
         keyboardType: 'number-pad',
+        disabled: !isActive,
       },
     },
     {
@@ -119,6 +133,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '最低點數 (選填)',
         keyboardType: 'number-pad',
+        disabled: !isActive,
       },
     },
     {
@@ -126,6 +141,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '最高點數 (選填)',
         keyboardType: 'number-pad',
+        disabled: !isActive,
       },
     },
   ];
@@ -136,6 +152,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
         point: `${inTask.point / 100}`,
         pointMin: `${inTask.pointMin / 100}`,
         pointMax: `${inTask.pointMax / 100}`,
+        isActive: inTask.isActive === 1,
       }));
       setVisible(true);
     }

--- a/components/ModifyTask.js
+++ b/components/ModifyTask.js
@@ -16,12 +16,12 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
   const [task, setTask] = useState({});
   const [errors, setErrors] = useState([]);
 
-  const isModified = inTask ? true : false;
-  const isActiveTask = task.isActive === undefined ? true : task.isActive;
+  const isEditMode = inTask ? true : false;
+  const isActiveTask = isEditMode ? task.isActive : true;
 
   const handleSubmit = async () => {
-    if (isModified && !await check('ORG_TX__UPDATE', true)) return;
-    if (!isModified && !await check('ORG_TX__CREATE', true)) return;
+    if (isEditMode && !await check('ORG_TX__UPDATE', true)) return;
+    if (!isEditMode && !await check('ORG_TX__CREATE', true)) return;
 
     const errors = fields.map(({ key, required }) => {
       if (required && !task[key]) {
@@ -41,7 +41,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
     const username = await AsyncStorage.getItem('app:username');
     const now = moment().toISOString();
 
-    if (!isModified) {
+    if (!isEditMode) {
       const data = Object.assign(task, {
         organizationId,
         isActive: 1,
@@ -87,7 +87,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         enabledLabel: '使用中',
         disabledLabel: '停用中',
-        hidden: !isModified,
+        hidden: !isEditMode,
       },
       type: 'switch',
     },
@@ -108,7 +108,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '任務名稱',
         autoCorrect: false,
-        disabled: isModified || !isActiveTask,
+        disabled: isEditMode,
       },
     },
     {
@@ -169,7 +169,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
           }}
         />}
       <CustomModal
-        title={`${isModified ? '修改':'新增'}任務`}
+        title={`${isEditMode ? '修改':'新增'}任務`}
         visible={visible}
         onClose={() => {
           resetState();

--- a/components/ModifyTask.js
+++ b/components/ModifyTask.js
@@ -17,7 +17,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
   const [errors, setErrors] = useState([]);
 
   const isModified = inTask ? true : false;
-  const isActive = task.isActive;
+  const isActiveTask = task.isActive === undefined ? true : task.isActive;
 
   const handleSubmit = async () => {
     if (isModified && !await check('ORG_TX__UPDATE', true)) return;
@@ -99,7 +99,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
         autoCorrect: false,
         autoCapitalize: 'none',
         placeholder: 'ex: 學校表現 日常工作',
-        disabled: !isActive,
+        disabled: !isActiveTask,
       },
     },
     {
@@ -108,7 +108,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '任務名稱',
         autoCorrect: false,
-        disabled: isModified || !isActive,
+        disabled: isModified || !isActiveTask,
       },
     },
     {
@@ -117,7 +117,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '任務內容',
         autoCorrect: false,
-        disabled: !isActive,
+        disabled: !isActiveTask,
       },
     },
     {
@@ -126,7 +126,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '點數',
         keyboardType: 'number-pad',
-        disabled: !isActive,
+        disabled: !isActiveTask,
       },
     },
     {
@@ -134,7 +134,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '最低點數 (選填)',
         keyboardType: 'number-pad',
-        disabled: !isActive,
+        disabled: !isActiveTask,
       },
     },
     {
@@ -142,7 +142,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         label: '最高點數 (選填)',
         keyboardType: 'number-pad',
-        disabled: !isActive,
+        disabled: !isActiveTask,
       },
     },
   ];

--- a/components/ModifyTask.js
+++ b/components/ModifyTask.js
@@ -87,6 +87,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       props: {
         enabledLabel: '使用中',
         disabledLabel: '停用中',
+        hidden: !isModified,
       },
       type: 'switch',
     },

--- a/components/ModifyTask.js
+++ b/components/ModifyTask.js
@@ -148,7 +148,10 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       <CustomModal
         title={`${isModified ? '修改':'新增'}任務`}
         visible={visible}
-        onClose={() => setVisible(false)}
+        onClose={() => {
+          setVisible(false);
+          onClose && onClose();
+        }}
         padding
         autoFocus={false}
         bottomButtonProps={{

--- a/components/ModifyTask.js
+++ b/components/ModifyTask.js
@@ -68,10 +68,15 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
       await request(updateOrganizationTask, { input: data });
     }
 
+    resetState();
+    onClose && onClose();
+  };
+
+  const resetState = () => {
     setIsLoading(false);
     setVisible(false);
     setTask({});
-    onClose && onClose();
+    setIsDirty(false);
   };
 
   const fields = [
@@ -149,7 +154,7 @@ export default function ModifyTask({ task: inTask, hideButton, onClose }) {
         title={`${isModified ? '修改':'新增'}任務`}
         visible={visible}
         onClose={() => {
-          setVisible(false);
+          resetState();
           onClose && onClose();
         }}
         padding

--- a/components/TaskList.js
+++ b/components/TaskList.js
@@ -107,13 +107,20 @@ export default function TaskList({ mode = 'edit', onSelect, disabled = false }) 
           next: (event) => {
             if (event) {
               const updatedTask = event.value.data.onUpdateOrganizationTask;
-              console.log(updatedTask);
+              // remove the original one first if found
+              programs.some((program) => {
+                const matchedTaskIndex = program.tasks.findIndex((x) => x.name === updatedTask.name);
+                if (matchedTaskIndex !== -1) {
+                  delete program.tasks[matchedTaskIndex];
+                  return true;
+                }
+                return false;
+              });
               const matchedProgram = programs.find((x) => x.name === updatedTask.programName);
               if (matchedProgram) {
-                const matchedTask = matchedProgram.tasks.find((x) => x.name === updatedTask.name);
-                Object.assign(matchedTask, updatedTask);
+                matchedProgram.tasks.push(updatedTask);
               } else {
-                programs.unshift({
+                programs.push({
                   name: updatedTask.programName,
                   tasks: [updatedTask],
                   isExpanded: true,

--- a/components/TaskList.js
+++ b/components/TaskList.js
@@ -111,7 +111,7 @@ export default function TaskList({ mode = 'edit', onSelect, disabled = false }) 
               programs.some((program) => {
                 const matchedTaskIndex = program.tasks.findIndex((x) => x.name === updatedTask.name);
                 if (matchedTaskIndex !== -1) {
-                  delete program.tasks[matchedTaskIndex];
+                  program.tasks.splice(matchedTaskIndex, 1);
                   return true;
                 }
                 return false;


### PR DESCRIPTION
1. 修改任務頁面的左上角放了一個switch可以停用該任務, 因為感覺這個switch比較適合放上面, 位置可以再討論, 配色目前用switch sample裡的顏色, 不知道幸福存摺有沒有要固定用什麼配色, 可以再調整
2. 任務停用後還是維持在原本的類別, 但是會放在該類別的最下方, badge會顯示'停用中, 最後沒有獨立一個類別是因為code的邏輯會變得怪怪的, 也許可以在設定頁面或某個地方設定任務列表要不要顯示停用的任務
3. 任務列表目前會先把類別排序, 類別裡按照任務名稱排序, 然後停用的會放在類別的最下方, 如果不適合可以調整